### PR TITLE
Replace `getUtxos <addr>` for `getWalletUtxos`

### DIFF
--- a/frontend/src/UnbondedStaking/ClosePool.purs
+++ b/frontend/src/UnbondedStaking/ClosePool.purs
@@ -4,7 +4,6 @@ import Contract.Prelude
 
 import Contract.Address
   ( getNetworkId
-  , getWalletAddress
   , ownPaymentPubKeyHash
   , scriptHashAddress
   )

--- a/frontend/src/UnbondedStaking/ClosePool.purs
+++ b/frontend/src/UnbondedStaking/ClosePool.purs
@@ -35,7 +35,7 @@ import Contract.TxConstraints
   , mustSpendScriptOutput
   , mustValidateIn
   )
-import Contract.Utxos (utxosAt)
+import Contract.Utxos (getWalletUtxos, utxosAt)
 import Control.Alt ((<|>))
 import Control.Monad.Maybe.Trans (MaybeT(..), lift, runMaybeT)
 import Ctl.Internal.Plutus.Conversion (fromPlutusAddress)
@@ -105,10 +105,6 @@ closeUnbondedPoolContract
   unless (userPkh == admin) $ throwContractError
     "closeUnbondedPoolContract: Admin is not current user"
   logInfo_ "closeUnbondedPoolContract: Admin PaymentPubKeyHash" userPkh
-  -- Get the (Nami) wallet address
-  adminAddr <-
-    liftedM "depositUnbondedPoolContract: Cannot get wallet Address"
-      getWalletAddress
   -- Get the unbonded pool validator and hash
   validator <- liftedE' "closeUnbondedPoolContract: Cannot create validator"
     $ mkUnbondedPoolValidator params scriptVersion
@@ -214,7 +210,8 @@ closeUnbondedPoolContract
   -- Submit transaction that closes state utxo separately (if necessary)
   stateUtxoConsumed <- case poolStateUtxo of
     Just (poolTxInput /\ _ /\ poolDatum) -> do
-      adminUtxos <- utxosAt adminAddr
+      adminUtxos <- liftedM "closeUnbondedPool: could not get wallet's utxos" $
+        getWalletUtxos
       Array.null <$> submitTransaction
         ( mustIncludeDatum poolDatum <> mustSpendScriptOutput poolTxInput
             redeemer
@@ -234,7 +231,8 @@ closeUnbondedPoolContract
       ( Array.zip entriesInputs
           (Array.zip entriesDatums updatedEntriesDatums)
       )
-  adminUtxos <- utxosAt adminAddr
+  adminUtxos <- liftedM "closeUnbondedPool: could not get wallet's utxos" $
+    getWalletUtxos
   failedCloses <-
     if batchSize == zero then
       submitTransaction

--- a/frontend/src/UnbondedStaking/CreatePool.purs
+++ b/frontend/src/UnbondedStaking/CreatePool.purs
@@ -27,7 +27,7 @@ import Contract.TxConstraints
   , mustMintValue
   , mustSpendPubKeyOutput
   )
-import Contract.Utxos (utxosAt)
+import Contract.Utxos (getWalletUtxos, utxosAt)
 import Contract.Value
   ( CurrencySymbol
   , Value
@@ -82,7 +82,9 @@ createUnbondedPoolContract iup scriptVersion =
     logInfo_ "createUnbondedPoolContract: User Address"
       =<< addressToBech32 adminAddr
     -- Get utxos at the wallet address
-    adminUtxos <- utxosAt adminAddr
+    adminUtxos <-
+      liftedM "createUnbondedPoolContract: Could not get wallet utxos"
+        $ getWalletUtxos
     logInfo_ "Admin utxos:" $ show adminUtxos
     txOutRef <-
       liftContractM "createUnbondedPoolContract: Could not get head UTXO"

--- a/frontend/src/UnbondedStaking/DepositPool.purs
+++ b/frontend/src/UnbondedStaking/DepositPool.purs
@@ -42,7 +42,7 @@ import Contract.TxConstraints
   , mustSpendScriptOutput
   , mustValidateIn
   )
-import Contract.Utxos (utxosAt)
+import Contract.Utxos (getWalletUtxos, utxosAt)
 import Contract.Value (mkTokenName, singleton)
 import Control.Applicative (unless)
 import Ctl.Internal.Plutus.Conversion (fromPlutusAddress)
@@ -113,12 +113,10 @@ depositUnbondedPoolContract
   unless (userPkh == admin) $ throwContractError
     "depositUnbondedPoolContract: Admin is not current user"
   logInfo_ "depositUnbondedPoolContract: Admin PaymentPubKeyHash" userPkh
-  -- Get the (Nami) wallet address
-  adminAddr <-
-    liftedM "depositUnbondedPoolContract: Cannot get wallet Address"
-      getWalletAddress
   -- Get utxos at the wallet address
-  adminUtxos <- utxosAt adminAddr
+  adminUtxos <-
+    liftedM "depositUnbondedPoolContract: Could not get wallet's utxos" $
+      getWalletUtxos
   -- Get the unbonded pool validator and hash
   validator <- liftedE' "depositUnbondedPoolContract: Cannot create validator"
     $ mkUnbondedPoolValidator params scriptVersion

--- a/frontend/src/UnbondedStaking/DepositPool.purs
+++ b/frontend/src/UnbondedStaking/DepositPool.purs
@@ -9,7 +9,6 @@ import Contract.Prelude
 
 import Contract.Address
   ( getNetworkId
-  , getWalletAddress
   , ownPaymentPubKeyHash
   , scriptHashAddress
   )

--- a/frontend/src/UnbondedStaking/UserStake.purs
+++ b/frontend/src/UnbondedStaking/UserStake.purs
@@ -4,7 +4,6 @@ import Contract.Prelude hiding (length)
 
 import Contract.Address
   ( getNetworkId
-  , getWalletAddress
   , ownPaymentPubKeyHash
   , scriptHashAddress
   )

--- a/frontend/src/UnbondedStaking/UserStake.purs
+++ b/frontend/src/UnbondedStaking/UserStake.purs
@@ -36,7 +36,7 @@ import Contract.TxConstraints
   , mustSpendScriptOutput
   , mustValidateIn
   )
-import Contract.Utxos (utxosAt)
+import Contract.Utxos (getWalletUtxos, utxosAt)
 import Contract.Value (Value, mkTokenName, singleton)
 import Control.Applicative (unless)
 import Ctl.Internal.Plutus.Conversion (fromPlutusAddress)
@@ -98,13 +98,10 @@ userStakeUnbondedPoolContract
     ownPaymentPubKeyHash
   logInfo_ "userStakeUnbondedPoolContract: User's PaymentPubKeyHash" userPkh
 
-  -- Get the (Nami) wallet address
-  userAddr <-
-    liftedM "userStakeUnbondedPoolContract: Cannot get wallet Address"
-      getWalletAddress
-
   -- Get utxos at the wallet address
-  userUtxos <- utxosAt userAddr
+  userUtxos <-
+    liftedM "userStakeUnbondedPoolContract: Cannot get wallet's utxos" $
+      getWalletUtxos
 
   -- Get the unbonded pool validator and hash
   validator <- liftedE' "userStakeUnbondedPoolContract: Cannot create validator"

--- a/frontend/src/UnbondedStaking/UserWithdraw.purs
+++ b/frontend/src/UnbondedStaking/UserWithdraw.purs
@@ -6,12 +6,11 @@ import Contract.Prelude hiding (length)
 
 import Contract.Address
   ( getNetworkId
-  , getWalletAddress
   , ownPaymentPubKeyHash
   , ownStakePubKeyHash
   , scriptHashAddress
   )
-import Contract.Log (logAesonInfo, logInfo')
+import Contract.Log (logInfo')
 import Contract.Monad
   ( Contract
   , liftContractM

--- a/frontend/src/UnbondedStaking/UserWithdraw.purs
+++ b/frontend/src/UnbondedStaking/UserWithdraw.purs
@@ -11,7 +11,7 @@ import Contract.Address
   , ownStakePubKeyHash
   , scriptHashAddress
   )
-import Contract.Log (logInfo')
+import Contract.Log (logAesonInfo, logInfo')
 import Contract.Monad
   ( Contract
   , liftContractM
@@ -47,7 +47,7 @@ import Contract.TxConstraints
   , mustSpendScriptOutput
   , mustValidateIn
   )
-import Contract.Utxos (UtxoMap, utxosAt)
+import Contract.Utxos (UtxoMap, getWalletUtxos, utxosAt)
 import Contract.Value (Value, mkTokenName, singleton)
 import Ctl.Internal.Plutus.Conversion (fromPlutusAddress)
 import Data.Array (catMaybes)
@@ -125,14 +125,10 @@ userWithdrawUnbondedPoolContract
     logInfo_ "userWithdrawUnbondedPoolContract: User's StakePubKeyHash"
       userStakingPubKeyHash
 
-    -- Get the (Nami) wallet address
-    userAddr <-
-      liftedM "userWithdrawUnbondedPoolContract: Cannot get wallet Address"
-        getWalletAddress
-    logInfo_ "userWithdrawUnbondedPoolContract: User's wallet address" userAddr
-
     -- Get utxos at the wallet address
-    userUtxos <- utxosAt userAddr
+    userUtxos <-
+      liftedM "userWithdrawUnbondedPoolContract: Cannot get wallet's utxos" $
+        getWalletUtxos
     logInfo_ "userWithdrawUnbondedPoolContract: User's UTxOs" userUtxos
 
     ---- FETCH POOL DATA ----


### PR DESCRIPTION
The reason for this change is to avoid including collateral UTxOs in the inputs of a TX, which generates problems for Eternl (and possibly other wallets) when validating the Ogmios UTxO set is included in the wallet UTxO set.