### PR TITLE
Add `open` field to `UserEntry`

### DIFF
--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -68,6 +68,7 @@ export type UserEntry = {
   deposited: BigInteger;
   rewards: Number;
   nextCycleRewards: Number;
+  open: boolean
 }
 
 // Unbonded pool

--- a/frontend/src/SdkApi.purs
+++ b/frontend/src/SdkApi.purs
@@ -489,6 +489,7 @@ type UserEntry =
   , deposited :: BigInt
   , rewards :: Rational
   , nextCycleRewards :: Rational
+  , open :: Boolean
   }
 
 callHashPkh :: String -> Effect (Promise ByteArray)
@@ -510,6 +511,7 @@ callQueryAssocListUnbondedPool env upa = Promise.fromAff $ runContractInEnv env
           , deposited: e.deposited
           , rewards: e.rewards
           , nextCycleRewards: calculateRewards (wrap e)
+          , open: e.open
           }
       )
       entries


### PR DESCRIPTION
This field can be useful in situations where a manual recovery is needed, such as in a situation where the pool is partially closed and there is no `IncompleteClose` object available and one needs to construct it by hand.